### PR TITLE
Fix parse url with regexp

### DIFF
--- a/lib/onlyoffice_documentserver_conversion_helper.rb
+++ b/lib/onlyoffice_documentserver_conversion_helper.rb
@@ -84,7 +84,7 @@ module OnlyofficeDocumentserverConversionHelper
     # Method will get link from response body.
     # Link start from 'https', and end from result file format
     def get_url_from_responce(data, file_format)
-      res_result = /(http|https).*(#{file_format})/.match(data)
+      res_result = /(http|https).*\.(#{file_format})/.match(data)
       CGI.unescapeHTML(res_result.to_s)
     end
 


### PR DESCRIPTION
Regexp script ignores important character set to parse the response. 

```regexp
 /(http|https).*(#{file_format})/
```

It gets the last character set equal to the file extension. But in the response, it is part of the data

```xml
</FileUrl><FileType>docx
```

If you make the script end the selection on an extension with a dot character, then the URL will return correctly.

Because every url in every response from the server ends with the character set `.${file_format}`