### PR TITLE
Add rspec for unformatted xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Use new uploader for `codecov` instead of deprecated one
 * Require `mfa` for releasing gem
+* Resolved the problem with the incorrect regexp script
 
 ## 0.2.0 (2021-01-27)
 

--- a/assets/responce/unformatte_response_example.xml
+++ b/assets/responce/unformatte_response_example.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><FileResult><FileUrl>http://localhost/filename=output.docx</FileUrl><FileType>docx</FileType><Percent>100</Percent><EndConvert>True</EndConvert></FileResult>

--- a/lib/onlyoffice_documentserver_conversion_helper/xml_responce_parser.rb
+++ b/lib/onlyoffice_documentserver_conversion_helper/xml_responce_parser.rb
@@ -11,7 +11,7 @@ class XmlResponceParser
   # returning url with unescape HTML
   # @return [String] URL
   def result_url
-    res_result = /(http|https).*(#{@file_format})/.match(@string_with_xml)
+    res_result = /(http|https).*\.(#{@file_format})/.match(@string_with_xml)
     CGI.unescapeHTML(res_result.to_s)
   end
 end

--- a/spec/onlyoffice_documentserver_conversion_helper/xml_responce_parser_spec.rb
+++ b/spec/onlyoffice_documentserver_conversion_helper/xml_responce_parser_spec.rb
@@ -7,15 +7,12 @@ describe XmlResponceParser do
     described_class.new(File.read('assets/responce/formatte_responce_example.xml'), 'docx')
   end
 
-  let(:parser_for_unformatted_xml) do
-    described_class.new(File.read('assets/responce/unformatte_response_example.xml'), 'docx')
-  end
-
   it 'eq result_url for template' do
     expect(parser.result_url).to eq('http://localhost/filename=output.docx')
   end
 
   it 'eq result_url for unformatted template' do
-    expect(parser_for_unformatted_xml.result_url).to eq('http://localhost/filename=output.docx')
+    parser = described_class.new(File.read('assets/responce/unformatte_response_example.xml'), 'docx')
+    expect(parser.result_url).to eq('http://localhost/filename=output.docx')
   end
 end

--- a/spec/onlyoffice_documentserver_conversion_helper/xml_responce_parser_spec.rb
+++ b/spec/onlyoffice_documentserver_conversion_helper/xml_responce_parser_spec.rb
@@ -7,7 +7,15 @@ describe XmlResponceParser do
     described_class.new(File.read('assets/responce/formatte_responce_example.xml'), 'docx')
   end
 
+  let(:parser_for_unformatted_xml) do
+    described_class.new(File.read('assets/responce/unformatte_response_example.xml'), 'docx')
+  end
+
   it 'eq result_url for template' do
     expect(parser.result_url).to eq('http://localhost/filename=output.docx')
+  end
+
+  it 'eq result_url for unformatted template' do
+    expect(parser_for_unformatted_xml.result_url).to eq('http://localhost/filename=output.docx')
   end
 end


### PR DESCRIPTION
Test Results

```
  0) XmlResponceParser eq result_url for unformatted template
     Failure/Error: expect(parser_for_unformatted_xml.result_url).to eq('http://localhost/filename=output.docx')

       expected: "http://localhost/filename=output.docx"
            got: "http://localhost/filename=output.docx</FileUrl><FileType>docx"
```