### PR TITLE
New way to set JWT via Payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * Add `yamllint` support in CI
+* Add request.body encoding to jwt payload
 
 ### Changes
 

--- a/lib/onlyoffice_documentserver_conversion_helper.rb
+++ b/lib/onlyoffice_documentserver_conversion_helper.rb
@@ -93,8 +93,7 @@ module OnlyofficeDocumentserverConversionHelper
     # @param [Net::HTTP::Post] request to add data
     # @return [Net::HTTP::Post] request with JWT
     def add_jwt_data(request)
-      json_to_ruby_data_structure = JSON.parse(request.body)
-      payload_to_encode = { 'payload' => json_to_ruby_data_structure }
+      payload_to_encode = { 'payload' => JSON.parse(request.body) }
       jwt_encoded = JWT.encode payload_to_encode, @jwt_key
       request[@jwt_header] = "#{@jwt_prefix} #{jwt_encoded}"
     end

--- a/lib/onlyoffice_documentserver_conversion_helper.rb
+++ b/lib/onlyoffice_documentserver_conversion_helper.rb
@@ -93,7 +93,8 @@ module OnlyofficeDocumentserverConversionHelper
     # @param [Net::HTTP::Post] request to add data
     # @return [Net::HTTP::Post] request with JWT
     def add_jwt_data(request)
-      payload_to_encode = { 'payload' => '{}' }
+      json_to_ruby_data_structure = JSON.parse(request.body)
+      payload_to_encode = { 'payload' => json_to_ruby_data_structure }
       jwt_encoded = JWT.encode payload_to_encode, @jwt_key
       request[@jwt_header] = "#{@jwt_prefix} #{jwt_encoded}"
     end


### PR DESCRIPTION
Added the [tokenRequiredParams](https://github.com/ONLYOFFICE/server/commit/342a23752d0ae2caac3b4b6b5eae129e32a80e49) flag in the commit, which prohibits empty "payload" for jwt

Added duplicate request_body to payload when generating token