### PR TITLE
Remove unused `ConvertFileData#get_url_from_responce` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Remove unused `ConvertFileData#get_url_from_responce` method
+
 ## 0.4.0 (2022-03-09)
 
 ### New Features

--- a/lib/onlyoffice_documentserver_conversion_helper.rb
+++ b/lib/onlyoffice_documentserver_conversion_helper.rb
@@ -79,16 +79,6 @@ module OnlyofficeDocumentserverConversionHelper
       params
     end
 
-    # @return [String] with url to result file
-    # @param [String] data is a response body
-    # @param [String] file_format is a format of result file
-    # Method will get link from response body.
-    # Link start from 'https', and end from result file format
-    def get_url_from_responce(data, file_format)
-      res_result = /(http|https).*(#{file_format})/.match(data)
-      CGI.unescapeHTML(res_result.to_s)
-    end
-
     # Add jwt data to request
     # @param [Net::HTTP::Post] request to add data
     # @return [Net::HTTP::Post] request with JWT


### PR DESCRIPTION
It's unused since:
https://github.com/ONLYOFFICE-QA/onlyoffice_documentserver_conversion_helper/commit/ebdc7e4f84bea09d2912df216d437164b394d034#diff-30190b63c04d50b8ab6f073b227362b3a052ddade42d239edb9a3d31f3f13834R151